### PR TITLE
Adding DEMO only information

### DIFF
--- a/webserver/accounts/templates/registration/login.html
+++ b/webserver/accounts/templates/registration/login.html
@@ -34,6 +34,9 @@
             {% elif view == 'register' %}
               <button type="submit" class="btn btn-primary btn-block">Register</button>
               <p class="text-center mt-3">
+                {% if DEMO %}
+                  Pssst, this is a demo version. The registration key is {{ REGISTRATION_KEY }}. 
+                {% endif %}
                 <a href="{% url 'login' %}">Already have an account? Login here.</a>
               </p>
             {% endif %}

--- a/webserver/accounts/views.py
+++ b/webserver/accounts/views.py
@@ -4,7 +4,7 @@ from django.shortcuts import render, redirect
 from django.contrib.auth.models import User
 from django.utils import timezone
 
-from mysite.settings import REGISTRATION_KEY
+from mysite.settings import REGISTRATION_KEY, DEMO
 from .forms import LoginForm, RegisterForm, ConsentForm, ProfileInfoForm, ProfilePasswordForm
 from .models import Consent
 
@@ -88,7 +88,7 @@ def register_(request):
             return redirect('/accounts/consent/')
         return redirect(request.GET.get('next', '/'))
 
-    return render(request, "registration/login.html", {'form': form, 'view': 'register', 'error': error})
+    return render(request, "registration/login.html", {'form': form, 'view': 'register', 'error': error, 'DEMO': DEMO, 'REGISTRATION_KEY': REGISTRATION_KEY})
 
 def logout_(request):
     if request.user.is_authenticated:

--- a/webserver/home/templates/home/index.html
+++ b/webserver/home/templates/home/index.html
@@ -2,18 +2,20 @@
 
 {% block content %}
 <main role="main">
-
-    <section class="jumbotron text-center">
-      <div class="container">
-        <br>
-        <h1 class="jumbotron-heading">SHARPIE website</h1>
-        <p class="lead text-muted">Shared Human-AI Reinforcement Learning Platform for Interactive Experiments</p>
-        <p>
-          <a href="https://arxiv.org/abs/2501.19245" target="_blank" class="btn btn-primary my-2">Check out our paper</a>
-          <a href="https://github.com/libgoncalv/SHARPIE" target="_blank" class="btn btn-secondary my-2">Check out our code</a>
-        </p>
-      </div>
-    </section>
+    
+    {% if DEMO %}
+      <section class="jumbotron text-center">
+        <div class="container">
+          <br>
+          <h1 class="jumbotron-heading">SHARPIE website</h1>
+          <p class="lead text-muted">Shared Human-AI Reinforcement Learning Platform for Interactive Experiments</p>
+          <p>
+            <a href="https://arxiv.org/abs/2501.19245" target="_blank" class="btn btn-primary my-2">Check out our paper</a>
+            <a href="https://github.com/hybrid-intelligence/SHARPIE" target="_blank" class="btn btn-secondary my-2">Check out our code</a>
+          </p>
+        </div>
+      </section>
+    {% endif %}
 
     <div class="album py-5 bg-adaptive">
       <div class="container">

--- a/webserver/home/views.py
+++ b/webserver/home/views.py
@@ -1,7 +1,9 @@
 from django.shortcuts import render
 from experiment.models import Experiment
 
+from mysite.settings import DEMO
+
 
 def index(request):
     experiments = Experiment.objects.all()
-    return render(request, "home/index.html", {"experiments": experiments})
+    return render(request, "home/index.html", {"experiments": experiments, "DEMO": DEMO})

--- a/webserver/mysite/settings.py
+++ b/webserver/mysite/settings.py
@@ -25,6 +25,8 @@ SECRET_KEY = 'django-insecure-n135)#u&k!m6k%dg4&&ek=_yj^d13y0q&j617hf9!&$t5y6x=_
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 PROD = False
+# Useful to add some information only for the self-hosted version at sharpie.science.uu.nl
+DEMO = False
 
 HTTPS = False
 if HTTPS:


### PR DESCRIPTION
Adding DEMO variable to settings and using that to display information only for the demo version such as links to our papers and code on home page, or registration key on register page.

Closes #43 
