### PR TITLE
Fix participant input handling in multi-participant experiments

### DIFF
--- a/runner/manage.py
+++ b/runner/manage.py
@@ -195,7 +195,7 @@ def override_actions(agents_settings, participant_inputs, policy_actions):
         if agents_settings[agent_name].get('inputs_type') == 'actions':
             default_val = agents_settings[agent_name].get('keyboard_inputs', {}).get('default', 0)
             # Only override if the participant actually provided a non-default input
-            if agent_name in final_actions and p_input != default_val:
+            if agent_name in final_actions and p_input == default_val:
                 continue
             if isinstance(final_actions, dict):
                 final_actions[agent_name] = p_input

--- a/webserver/experiment/static/experiment/js/websocket.js
+++ b/webserver/experiment/static/experiment/js/websocket.js
@@ -68,7 +68,7 @@ document.addEventListener('instruction-submit', function(e) {
 });
 
 function sendAction(action) {
-    websocket.send(JSON.stringify({type: 'broadcast', action: action}));
+    websocket.send(JSON.stringify({type: 'private', action: action}));
 }
 
 // When the server finishes a step and replies

--- a/webserver/experiment/websocket.py
+++ b/webserver/experiment/websocket.py
@@ -112,7 +112,7 @@ class RunConsumer(RunConsumerHelpers, AsyncWebsocketConsumer):
         message = json.loads(text_data)
         if message["type"] == 'broadcast':
             await self._handle_broadcast(message)
-        elif message.get("type") == 'private' and message.get("message") == 'action':
+        elif message.get("type") == 'private' and "action" in message:
             await self._handle_action(message)
         elif message.get("message") == 'settings':
             await self._handle_settings()


### PR DESCRIPTION
## Summary

This PR fixes three bugs in participant input handling:

1. **Corrected action override logic** in `runner/manage.py:198` - inverted boolean to properly skip override when participant provides default input value
2. **Changed message type to private** in `websocket.js` - participant actions now use `type: 'private'` instead of `type: 'broadcast'`
3. **Improved message detection** in `websocket.py:115` - checks for presence of `'action'` key rather than matching a specific message value

## Why

These bugs were causing incorrect behavior in multi-participant experiments:

- The inverted logic in `override_actions()` meant participant inputs were being overwritten when they shouldn't be, and preserved when they should be overridden
- Broadcasting participant actions to all users was exposing individual inputs to other participants, violating privacy expectations
- The brittle message type checking made the system fragile to minor changes in message structure

## Testing

To verify these fixes:

- Run multi-participant experiments with action-type inputs
- Test that default inputs (no action taken) are not incorrectly overridden
- Test that non-default participant inputs properly override policy actions
- Verify participant actions are sent privately and not visible to other participants
- Confirm WebSocket message handling correctly identifies action messages