### PR TITLE
fix: use wildcard syntax for sharpie-web supervisor commands

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -23,4 +23,4 @@ jobs:
           cd webserver
           python manage.py migrate
           python manage.py collectstatic --noinput
-          supervisorctl restart sharpie-web sharpie-runner
+          supervisorctl restart sharpie-web:* sharpie-runner

--- a/deployment/DEPLOYMENT.md
+++ b/deployment/DEPLOYMENT.md
@@ -90,7 +90,7 @@ If a deployment causes issues:
    cd webserver
    python manage.py migrate
    python manage.py collectstatic --noinput
-   supervisorctl restart sharpie-web
+   supervisorctl restart sharpie-web:*
    supervisorctl restart sharpie-runner
    ```
 
@@ -139,7 +139,7 @@ Installed automatically from `requirements.txt` during deployment.
 
 **Services don't restart**
 - Verify supervisor is running: `sudo systemctl status supervisor`
-- Check supervisor logs: `sudo supervisorctl tail sharpie-web`
+   - Check supervisor logs: `sudo supervisorctl tail sharpie-web:*`
 - Verify user is in the supervisor group
 
 **Database migrations fail**
@@ -159,7 +159,7 @@ Installed automatically from `requirements.txt` during deployment.
 supervisorctl status
 
 # View service logs
-supervisorctl tail -f sharpie-web
+ supervisorctl tail -f sharpie-web:*
 supervisorctl tail -f sharpie-runner
 
 # Restart specific service

--- a/deployment/SERVER_SETUP.md
+++ b/deployment/SERVER_SETUP.md
@@ -320,7 +320,7 @@ DATABASE_URL=postgres://sharpie:your-secure-password@localhost/sharpie
 sudo supervisorctl status
 
 # Should show:
-# sharpie-web:running
+ # sharpie-web0:running
 
 # Check if application is responding
 curl http://localhost:8000
@@ -402,11 +402,11 @@ sudo chown root:supervisor /var/run/supervisor.sock
 sudo tail -f /var/log/supervisor/supervisord.log
 
 # Check program logs
-sudo supervisorctl tail -f sharpie-web
+ sudo supervisorctl tail -f sharpie-web:*
 sudo supervisorctl tail -f sharpie-runner
 
 # Manually start programs
-sudo supervisorctl start sharpie-web
+ sudo supervisorctl start sharpie-web:*
 sudo supervisorctl restart sharpie-runner
 ```
 


### PR DESCRIPTION
## Summary
Updated all supervisor commands to use `sharpie-web:*` wildcard syntax instead of `sharpie-web` to properly match the process names created by the fcgi-program configuration.

## Why
The deployment workflow was failing with the error:
```
sharpie-web: ERROR (no such process)
```

This occurred because the `fcgi-program` configuration with `numprocs=1` and `process_name=sharpie-web%(process_num)d` creates a process named `sharpie-web0`, not `sharpie-web`. The deployment commands were trying to restart a process that didn't exist.

Using wildcard syntax (`sharpie-web:*`) ensures supervisor commands match all processes in the sharpie-web group regardless of the process number suffix.

## Testing
- Verified all command references in deployment workflow and documentation
- Changes are limited to supervisor command syntax only
- No configuration changes to the actual supervisor setup
- Wildcard syntax is supported by supervisorctl for process groups