### PR TITLE
feat: Add automatic use-case installation to CD workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -23,4 +23,12 @@ jobs:
           cd webserver
           python manage.py migrate
           python manage.py collectstatic --noinput
-          supervisorctl restart sharpie-web:* sharpie-runner
+          
+      - name: Install use-cases from Gallery
+        run: |
+          cd /var/www/sharpie
+          source venv/bin/activate
+          bash scripts/install_use_cases.sh
+          
+      - name: Restart services
+        run: supervisorctl restart sharpie-web:* sharpie-runner

--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,6 @@ cython_debug/
 db.sqlite3
 
 __init__.py
+# Use-case installation logs
+logs/*.log
+!logs/.gitkeep

--- a/deployment/DEPLOYMENT.md
+++ b/deployment/DEPLOYMENT.md
@@ -181,6 +181,102 @@ sudo systemctl status redis-server
 redis-cli ping
 ```
 
+## Use-Case Installation
+
+SHARPIE automatically installs demo use-cases from the [SHARPIE_Gallery](https://github.com/hybrid-intelligence/SHARPIE_Gallery) repository during deployment. Use-cases are experiment configurations (environments, policies, agents) that users can run immediately.
+
+### How It Works
+
+1. **Deployment workflow** runs `scripts/install_use_cases.sh`
+2. **Script clones** the SHARPIE_Gallery repository
+3. **For each use-case** listed in `deployment/use_cases.txt`:
+   - Copies files to `runner/<use_case>/` directory
+   - Installs Python dependencies
+   - Creates database entries (Environment, Policy, Agent, Experiment)
+4. **Cleanup** removes temporary files
+
+### Configuration
+
+Edit `deployment/use_cases.txt` to customize which use-cases are installed:
+
+```
+# Lightweight demo use-cases (Python >= 3.13 compatible):
+amaze
+frozen
+mountain
+spread
+tag
+
+# Resource-intensive use-cases (disabled for demo server):
+# mario (requires gym-super-mario-bros)
+# overcooked (requires Python 3.10.x)
+```
+
+### Available Use-Cases
+
+Run `python install.py --list` in the SHARPIE_Gallery repository to see all available use-cases.
+
+**Lightweight (recommended for demo servers):**
+- **amaze** - Maze navigation with TAMER (minimal dependencies)
+- **frozen** - Frozen lake with TAMER (minimal dependencies)
+- **mountain** - Mountain car human-only (minimal dependencies)
+- **spread** - Multi-agent coordination (minimal dependencies)
+- **tag** - Multi-agent pursuit (minimal dependencies)
+
+**Medium weight (optional):**
+- **mario** - Super Mario Bros behavior cloning (requires gym-super-mario-bros)
+
+**Heavy weight (avoid on demo servers):**
+- **overcooked** - Collaborative cooking (requires Python 3.10.x specifically)
+- **saycan** - Language-conditioned manipulation (requires Python 3.10.x, JAX, TensorFlow)
+- **smacv2** - StarCraft II challenge (requires Python 3.10.x, heavy dependencies)
+
+### Manual Installation
+
+To manually install use-cases outside of deployment:
+
+```bash
+# Clone Gallery
+git clone https://github.com/hybrid-intelligence/SHARPIE_Gallery.git /tmp/SHARPIE_Gallery
+
+# Install specific use-case
+cd /tmp/SHARPIE_Gallery
+python install.py <use_case> --sharpie-dir /var/www/sharpie
+
+# Or run the deployment script
+cd /var/www/sharpie
+source venv/bin/activate
+bash scripts/install_use_cases.sh
+```
+
+### Troubleshooting
+
+**Use-case installation fails:**
+- Check logs: `tail -f /var/www/sharpie/logs/use_cases_install.log`
+- Verify Python version compatibility (use-case requires Python >= 3.13)
+- Check if dependencies are installed: `pip list`
+- Verify database migrations: `cd webserver && python manage.py showmigrations`
+
+**Use-case not appearing in admin:**
+- Verify installation succeeded in logs
+- Check database: `cd webserver && python manage.py dbshell`
+  ```sql
+  SELECT * FROM experiment_experiment;
+  ```
+- Verify files exist: `ls -la /var/www/sharpie/runner/<use_case>/`
+
+**Experiments won't start:**
+- Check runner logs: `sudo supervisorctl tail -f sharpie-runner`
+- Verify runner is connected: Check Django logs for WebSocket connection
+- Ensure use-case files are in runner directory
+
+**Reinstall all use-cases:**
+```bash
+cd /var/www/sharpie
+source venv/bin/activate
+bash scripts/install_use_cases.sh
+```
+
 ## Monitoring
 
 Consider setting up:

--- a/deployment/use_cases.txt
+++ b/deployment/use_cases.txt
@@ -1,0 +1,16 @@
+# Use-cases to install in production (demo server)
+# One use-case per line, lines starting with # are comments
+# Use 'python install.py --list' in SHARPIE_Gallery to see all available use-cases
+
+# Lightweight demo use-cases (Python >= 3.13 compatible):
+amaze
+frozen
+mountain
+spread
+tag
+
+# Resource-intensive use-cases (disabled for demo server):
+# mario (requires gym-super-mario-bros)
+# overcooked (requires Python 3.10.x)
+# saycan (requires Python 3.10.x)
+# smacv2 (requires Python 3.10.x)

--- a/scripts/install_use_cases.sh
+++ b/scripts/install_use_cases.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -e  # Exit on error (but continue to next use-case if one fails)
+
+# Configuration
+SHARPIE_DIR="/var/www/sharpie"
+WEBSERVER_DIR="$SHARPIE_DIR/webserver"
+RUNNER_DIR="$SHARPIE_DIR/runner"
+GALLERY_REPO="https://github.com/hybrid-intelligence/SHARPIE_Gallery.git"
+TEMP_DIR="/tmp/SHARPIE_Gallery_$$"  # Unique temp directory
+USE_CASES_FILE="$SHARPIE_DIR/deployment/use_cases.txt"
+LOG_FILE="$SHARPIE_DIR/logs/use_cases_install.log"
+
+# Ensure logs directory exists
+mkdir -p "$(dirname "$LOG_FILE")"
+
+# Function to log messages
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"
+}
+
+# Clone SHARPIE_Gallery
+log "Cloning SHARPIE_Gallery..."
+git clone --depth 1 "$GALLERY_REPO" "$TEMP_DIR"
+
+# Read use-cases from config file
+USE_CASES=$(grep -v '^#' "$USE_CASES_FILE" | grep -v '^$' || true)
+
+if [ -z "$USE_CASES" ]; then
+    log "ERROR: No use-cases found in $USE_CASES_FILE"
+    exit 1
+fi
+
+# Install each use-case
+FAILED_USE_CASES=""
+for use_case in $USE_CASES; do
+    log "Installing use-case: $use_case"
+    
+    # Check if use-case directory exists in Gallery
+    if [ ! -d "$TEMP_DIR/$use_case" ]; then
+        log "✗ Use-case not found: $use_case"
+        FAILED_USE_CASES="$FAILED_USE_CASES $use_case"
+        continue
+    fi
+    
+    # Copy use-case files to runner directory
+    # Each use-case has environment.py, policy.py, etc. in its directory
+    # These need to be accessible from the runner
+    if [ -d "$TEMP_DIR/$use_case" ]; then
+        log "  Copying files to runner directory..."
+        mkdir -p "$RUNNER_DIR/$use_case"
+        cp -r "$TEMP_DIR/$use_case"/* "$RUNNER_DIR/$use_case/"
+        log "  ✓ Files copied to: $RUNNER_DIR/$use_case"
+    fi
+    
+    # Install dependencies and update database
+    if python "$TEMP_DIR/install.py" "$use_case" \
+         --sharpie-dir "$SHARPIE_DIR" \
+         --webserver-dir "$WEBSERVER_DIR" \
+         --quiet 2>&1 | tee -a "$LOG_FILE"; then
+        log "✓ Successfully installed: $use_case"
+    else
+        log "✗ Failed to install: $use_case"
+        FAILED_USE_CASES="$FAILED_USE_CASES $use_case"
+        # Clean up copied files if installation failed
+        rm -rf "$RUNNER_DIR/$use_case"
+    fi
+done
+
+# Cleanup
+log "Cleaning up..."
+rm -rf "$TEMP_DIR"
+
+# Summary
+if [ -n "$FAILED_USE_CASES" ]; then
+    log "WARNING: Some use-cases failed to install:$FAILED_USE_CASES"
+    log "Deployment continuing with successful installations."
+    # Don't exit with error - allow deployment to continue
+fi
+
+log "Use-case installation complete."


### PR DESCRIPTION
## Summary

This PR adds automatic installation of demo use-cases from the SHARPIE_Gallery repository during production deployments. The deployment workflow now clones the Gallery, installs selected lightweight use-cases (amaze, frozen, mountain, spread, tag), and creates database entries for Experiments, Environments, Policies, and Agents.

**Key changes:**
- New configuration file `deployment/use_cases.txt` to specify which use-cases to install
- New script `scripts/install_use_cases.sh` that clones SHARPIE_Gallery, copies use-case files to runner directory, and runs Gallery's install.py for each use-case
- Updated deployment workflow to run use-case installation after migrations
- Comprehensive documentation in deployment/DEPLOYMENT.md
- Logs directory added for installation output

## Why

The production demo server needs use-cases (experiments) available for users to run immediately after deployment. Previously, use-cases had to be installed manually. This automation ensures that:

1. **Fresh deployments have demo content** - No manual intervention needed to populate experiments
2. **Consistent environment** - All deployments use the same set of demo use-cases
3. **Lightweight selection** - Only Python 3.13+ compatible use-cases are installed by default, suitable for resource-constrained demo servers
4. **Idempotent operations** - Re-running on every deployment is safe (uses update_or_create)

**Validation:**
- Error handling allows deployment to continue even if individual use-cases fail