### PR TITLE
Fix: Wait for all expected participants before starting experiment

### DIFF
--- a/webserver/experiment/consumer_helpers.py
+++ b/webserver/experiment/consumer_helpers.py
@@ -29,9 +29,20 @@ class RunConsumerHelpers:
 
             # Refresh to get the actual value
             session.refresh_from_db()
-            participants_count = session.participants.count()
+            
+            # Get expected number of participants from experiment's agent configuration
+            expected_count = session.experiment.agents.filter(participant=True).count()
 
-            return session.connected_participants == participants_count
+            return session.connected_participants == expected_count
+
+    def _do_decrement(self):
+        """Atomically decrement participant count (only if session not yet running)."""
+        with transaction.atomic():
+            session = Session.objects.select_for_update().get(pk=self.session.pk)
+            # Only decrement if session hasn't started yet
+            if session.status in ['not_ready', 'ready'] and session.connected_participants > 0:
+                session.connected_participants = F('connected_participants') - 1
+                session.save(update_fields=['connected_participants'])
 
     def _fetch_episode_info(self):
         """Fetch episode completion info from database."""

--- a/webserver/experiment/websocket.py
+++ b/webserver/experiment/websocket.py
@@ -247,9 +247,11 @@ class RunConsumer(RunConsumerHelpers, AsyncWebsocketConsumer):
                 # Session may have been deleted
                 return
 
-        # If this is a participant (not a runner) and the session is completed or aborted,
-        # we need to update their session to reflect they're no longer in that session
+        # If this is a participant (not a runner), handle disconnection
         if not self.runner and hasattr(self, 'session'):
+            # Decrement connected participants count if session hasn't started
+            await database_sync_to_async(self._do_decrement)()
+            
             # Refresh the session from the database to get the latest status
             try:
                 await database_sync_to_async(self.session.refresh_from_db)()


### PR DESCRIPTION
## Summary

Fixed a bug where experiments would start before all expected human participants had connected via WebSocket. The system now correctly waits for all participants defined in the experiment configuration (agents with `participant=True`) to connect before transitioning to `'pending'` status.

## Why

Previously, `_do_increment` compared `connected_participants` against `session.participants.count()` (current registrations), not the expected number of participants. This meant:

- If an experiment required 2 participants and only 1 had registered and connected
- `connected_participants = 1` and `participants.count() = 1`
- The check `1 == 1` passed incorrectly
- Experiment started with only 1 participant

Additionally, `connected_participants` was never decremented when participants disconnected, causing reconnection issues where the counter could reach the expected count without all participants actually being connected.

## Testing

- Tested experiment with 2 expected human participants - now correctly waits for both to connect
- Tested disconnect/reconnect scenarios - counter properly decrements on disconnect
- Atomic database operations ensure thread safety for concurrent connections
- Session status checks prevent decrementing after experiment starts