### PR TITLE
Fix: Capture correct exit code from install script

### DIFF
--- a/scripts/install_use_cases.sh
+++ b/scripts/install_use_cases.sh
@@ -53,10 +53,14 @@ for use_case in $USE_CASES; do
     fi
     
     # Install dependencies and update database
-    if python "$TEMP_DIR/install.py" "$use_case" \
+    OUTPUT=$(python "$TEMP_DIR/install.py" "$use_case" \
          --sharpie-dir "$SHARPIE_DIR" \
          --webserver-dir "$WEBSERVER_DIR" \
-         --quiet 2>&1 | tee -a "$LOG_FILE"; then
+         --quiet 2>&1)
+    EXIT_CODE=$?
+    echo "$OUTPUT" | tee -a "$LOG_FILE"
+    
+    if [ $EXIT_CODE -eq 0 ]; then
         log "✓ Successfully installed: $use_case"
     else
         log "✗ Failed to install: $use_case"


### PR DESCRIPTION

## Summary

Fixed a bash pipeline issue that caused the installation script to always report success, even when use-case installations failed with errors like database locks, missing dependencies, or Python exceptions.

## Why

The script used a pipeline (`python ... | tee`) where the `if` statement captured `tee`'s exit code (always 0) instead of the Python script's actual exit code. This masked real failures in production deployments.

**Root cause:**
```bash
if python "$TEMP_DIR/install.py" ... | tee -a "$LOG_FILE"; then
    # This always succeeded because tee returns 0
```

**Fix:**
```bash
OUTPUT=$(python "$TEMP_DIR/install.py" ...)
EXIT_CODE=$?
echo "$OUTPUT" | tee -a "$LOG_FILE"

if [ $EXIT_CODE -eq 0 ]; then
```