### PR TITLE
fix: show error details when use-case installation fails

### DIFF
--- a/scripts/install_use_cases.sh
+++ b/scripts/install_use_cases.sh
@@ -53,11 +53,13 @@ for use_case in $USE_CASES; do
     fi
     
     # Install dependencies and update database
+    set +e  # Temporarily disable exit on error
     OUTPUT=$(python "$TEMP_DIR/install.py" "$use_case" \
          --sharpie-dir "$SHARPIE_DIR" \
          --webserver-dir "$WEBSERVER_DIR" \
          --quiet 2>&1)
     EXIT_CODE=$?
+    set -e  # Re-enable exit on error
     echo "$OUTPUT" | tee -a "$LOG_FILE"
     
     if [ $EXIT_CODE -eq 0 ]; then


### PR DESCRIPTION
## Summary

Fixes the CD workflow to display error details when a use-case installation fails, instead of exiting silently.

## Why

The `install_use_cases.sh` script uses `set -e` (exit on error). When `python install.py` failed inside a command substitution `$(...)`, the script would exit immediately before capturing and displaying the error output. This made debugging failures impossible.