### PR TITLE
Fix: Disable amaze use-case to prevent installation failures on Python 3.12+

### DIFF
--- a/deployment/use_cases.txt
+++ b/deployment/use_cases.txt
@@ -3,7 +3,7 @@
 # Use 'python install.py --list' in SHARPIE_Gallery to see all available use-cases
 
 # Lightweight demo use-cases (Python >= 3.13 compatible):
-amaze
+# amaze (disabled - requires numpy<2.0.0, incompatible with Python 3.12+)
 frozen
 mountain
 spread


### PR DESCRIPTION
## Summary
Disabled the `amaze` use-case in `deployment/use_cases.txt` to prevent installation failures during deployment.

## Why
- `amaze-benchmarker` has a dependency constraint `numpy<2.0.0`