### PR TITLE
fix: resolve Read the Docs build failure caused by myst-parser v3 API change

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,6 +17,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.intersphinx',
+    'myst_parser',
 ]
 
 intersphinx_mapping = {

--- a/docs/source/dependencies.rst
+++ b/docs/source/dependencies.rst
@@ -27,7 +27,7 @@ Python (PIP) Dependencies
 -------------------------
 
 .. include:: ../../DEPENDENCIES_PIP.md
-   :parser: myst_parser
+   :parser: myst_parser.parsers.docutils_
 
 System Dependencies
 -------------------


### PR DESCRIPTION
## Summary
Fix the Read the Docs build that was failing with `AttributeError: module 'myst_parser' has no attribute 'Parser'`. Solve #120.

## Why
myst-parser v3 moved the `Parser` class from the top-level `myst_parser` module to `myst_parser.parsers.docutils_`. The `.. include::` directive in `dependencies.rst` used `:parser: myst_parser`, which triggered docutils' parser lookup expecting `module.Parser` at the top level. Additionally, `myst_parser` was not registered as a Sphinx extension, preventing proper parser initialization.

## Testing
Built the docs locally using the sharpie conda environment with `python -m sphinx -T -b html source _build/html` — build succeeds with no errors (only pre-existing RST underline warnings).