### PR TITLE
fix: resolve install script database lookup failure in production CD

### DIFF
--- a/deployment/SERVER_SETUP.md
+++ b/deployment/SERVER_SETUP.md
@@ -289,7 +289,7 @@ exit
 
 ## Step 10: Configure Environment Variables
 
-Create environment file for Django settings:
+Create environment file for Django settings. **The `.env` file and `db.sqlite3` (if using SQLite) must reside in the webserver directory** because Django resolves their paths relative to the current working directory (CWD). Daphne's CWD is set via the `directory=` directive in the supervisor config, and any script that uses Django (e.g., `sharpie-web migrate`, `install.py`) must also `cd` into this directory first.
 
 ```bash
 # On the server as sharpie-deploy

--- a/deployment/webserver_supervisor.conf
+++ b/deployment/webserver_supervisor.conf
@@ -1,6 +1,8 @@
 [fcgi-program:sharpie-web]
 socket=tcp://localhost:8000
 
+# The directory directive sets the CWD for Daphne, which Django uses to
+# locate .env and db.sqlite3. Any script invoking Django must also cd here first.
 directory=/var/www/sharpie/webserver/
 
 environment=PATH=/var/www/sharpie/venv/bin/

--- a/scripts/install_use_cases.sh
+++ b/scripts/install_use_cases.sh
@@ -48,13 +48,16 @@ for use_case in $USE_CASES; do
     if [ -d "$TEMP_DIR/$use_case" ]; then
         log "  Copying files to runner directory..."
         mkdir -p "$RUNNER_DIR/$use_case"
+        # Clean __pycache__ from Gallery repo to avoid permission errors on cleanup
+        find "$TEMP_DIR/$use_case" -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
         cp -r "$TEMP_DIR/$use_case"/* "$RUNNER_DIR/$use_case/"
         log "  ✓ Files copied to: $RUNNER_DIR/$use_case"
     fi
     
     # Install dependencies and update database
+    # Must cd into WEBSERVER_DIR so Django finds .env and db.sqlite3 via CWD
     set +e  # Temporarily disable exit on error
-    OUTPUT=$(python "$TEMP_DIR/install.py" "$use_case" \
+    OUTPUT=$(cd "$WEBSERVER_DIR" && python "$TEMP_DIR/install.py" "$use_case" \
          --sharpie-dir "$SHARPIE_DIR" \
          --webserver-dir "$WEBSERVER_DIR" \
          --quiet 2>&1)


### PR DESCRIPTION
## Summary

Production CD was failing with `django.db.utils.OperationalError: no such table: experiment_environment` when installing use-cases from Gallery, alongside `Permission denied` errors removing `__pycache__` files.

## Why

Django's `settings.py` resolves `.env` and `db.sqlite3` paths relative to `CWD` (current working directory). Daphne and `sharpie-web migrate` run from `/var/www/sharpie/webserver/`, so they find these files correctly. However, `install_use_cases.sh` invoked `install.py` from `/var/www/sharpie/`, causing Django to look for `.env` and `db.sqlite3` in the wrong directory.

Additionally, `cp -r` from the Gallery repo brought along `__pycache__` directories that caused permission errors during cleanup.

## Testing

- Verified that `install_use_cases.sh` now `cd`s into `$WEBSERVER_DIR` before running `install.py`, matching the CWD that Daphne and `sharpie-web migrate` use
- Verified that `__pycache__` directories are cleaned from Gallery files before copying to the runner directory
- Confirmed supervisor config and SERVER_SETUP.md documentation accurately reflect the CWD dependency