### PR TITLE
fix: add __str__ method to Policy model for admin display

### DIFF
--- a/sharpie/webserver/experiment/models.py
+++ b/sharpie/webserver/experiment/models.py
@@ -68,6 +68,9 @@ class Policy(models.Model):
             raise ValidationError({
                 'filepaths': f'Error parsing policy file {policy_file_path}: {str(e)}'
             })
+            
+    def __str__(self):
+        return self.name
 
 class Agent(models.Model):
     """
@@ -172,6 +175,7 @@ class Environment(models.Model):
             raise ValidationError({
                 'filepaths': f'Error parsing environment file {env_file_path}: {str(e)}'
             })
+
     def __str__(self):
         return self.name
 


### PR DESCRIPTION
## Summary

Adds a `__str__` method to the `Policy` model that returns `self.name`, so policy objects display their name instead of an unhelpful default representation in the Django admin.

## Why

Closes #127. Without a `__str__` method, the Policy model fell back to Django's default `Model.__str__` which shows something like `Policy object (1)`. This made it difficult to identify policies in the agent admin form and elsewhere. The `Agent` and `Environment` models already had proper `__str__` methods.

## Testing

- Verified the `Policy.__str__` method returns `self.name` as expected