### PR TITLE
fix: replace git pull with fetch+reset to avoid deploy conflicts

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -17,7 +17,8 @@ jobs:
       - name: Deploy to production
         run: |
           cd /var/www/sharpie
-          git pull origin main
+          git fetch origin
+          git reset --hard origin/main
           source venv/bin/activate
           pip install -e .
           cd webserver

--- a/scripts/install_use_cases.sh
+++ b/scripts/install_use_cases.sh
@@ -19,7 +19,8 @@ log() {
 # Clone or update SHARPIE_Gallery
 if [ -d "$GALLERY_DIR" ]; then
     log "Updating existing SHARPIE_Gallery..."
-    git -C "$GALLERY_DIR" pull
+    git -C "$GALLERY_DIR" fetch origin
+    git -C "$GALLERY_DIR" reset --hard origin/main
 else
     log "Cloning SHARPIE_Gallery..."
     git clone --depth 1 "$GALLERY_REPO" "$GALLERY_DIR"


### PR DESCRIPTION
## Summary

Replace `git pull` with `git fetch origin` + `git reset --hard origin/main` in both the deploy workflow and the Gallery update script to prevent merge conflicts caused by uncommitted local changes.

## Why

Deployments were failing with:

```
error: Your local changes to the following files would be overwritten by merge:
Please commit your changes or stash them before you merge.
Aborting
```

This happened because `sharpie-install` or manual edits left uncommitted changes in the local clones. In a deployment context, the server should mirror the remote exactly — local modifications are not the source of truth. Using `fetch + reset --hard` forces the local state to match the remote, avoiding any merge conflict.

## Testing

- Verify the deploy workflow runs successfully on the self-hosted runner
- Confirm that both the main repo and SHARPIE_Gallery repo update cleanly even when local files have been modified