### PR TITLE
fix: run use-case installer from webserver directory to resolve correct database

### DIFF
--- a/scripts/install_use_cases.sh
+++ b/scripts/install_use_cases.sh
@@ -11,6 +11,10 @@ LOG_FILE="$SHARPIE_DIR/logs/use_cases_install.log"
 # Ensure logs directory exists
 mkdir -p "$(dirname "$LOG_FILE")"
 
+# Ensure we run from the webserver directory (same CWD as sharpie-web migrate)
+# so that Django resolves db.sqlite3 to the correct path
+cd "$SHARPIE_DIR/webserver"
+
 # Function to log messages
 log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"


### PR DESCRIPTION
## Summary

Add `cd "$SHARPIE_DIR/webserver"` to `install_use_cases.sh` so that `sharpie-install` runs from the same working directory as `sharpie-web migrate`.