### PR TITLE
ci: stop services before database writes to prevent SQLite lock

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -25,6 +25,9 @@ jobs:
           sharpie-web migrate
           sharpie-web collectstatic --noinput
           
+      - name: Stop services before database writes
+        run: supervisorctl stop sharpie-web:* sharpie-runner
+
       - name: Install use-cases from Gallery
         run: |
           cd /var/www/sharpie
@@ -32,4 +35,4 @@ jobs:
           bash scripts/install_use_cases.sh
           
       - name: Restart services
-        run: supervisorctl restart sharpie-web:* sharpie-runner
+        run: supervisorctl start sharpie-web:* sharpie-runner


### PR DESCRIPTION
## Summary

Stop the Daphne webserver and runner services before running use-case installations, and start them again afterward.

## Why

The previous fix (running `sharpie-install` from the `webserver/` directory) resolved the "no such table" error by pointing to the correct database file. However, it exposed a new error: `sqlite3.OperationalError: database is locked`. SQLite only allows one writer at a time, and the running Daphne process was holding a write lock on `db.sqlite3` during use-case installation.

By stopping services before database writes and starting them after, we eliminate concurrent write access to the SQLite database.